### PR TITLE
Format date with intl instead of moment

### DIFF
--- a/components/ImageDetails/ImageDetails.jsx
+++ b/components/ImageDetails/ImageDetails.jsx
@@ -1,5 +1,5 @@
 import { MdiCalendarMonth } from '../../assets/svgs/CalendarIcon'
-import moment from 'moment'
+import { formatDate } from '../../utils/formatDate'
 import Location from './../Location/Location'
 import Tags from './../Tags/Tags'
 import { imageDetailsStrings } from '../../data/strings'
@@ -13,7 +13,7 @@ const ImageDetails = ({ image: { user, created_at, tags, description } }) => {
 			<div>
 				<span className="flex items-center">
 					<MdiCalendarMonth className="text-lg mr-1" /> {imageDetailsStrings.publishText}{' '}
-					{moment(created_at).format('MMM Do YYYY')}
+					{formatDate(created_at)}
 				</span>
 			</div>
 			{tags.length !== 0 && <Tags tags={tags} />}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "commitizen": "^4.2.4",
     "cz-conventional-changelog": "^3.3.0",
     "eslint-plugin-babel": "^5.3.1",
-    "moment": "^2.29.1",
     "naughty-words": "^1.2.0",
     "next": "latest",
     "postcss-preset-env": "^6.7.0",

--- a/utils/formatDate.js
+++ b/utils/formatDate.js
@@ -1,0 +1,7 @@
+export const formatDate = (date) => {
+	let d = new Date(date)
+	let ye = new Intl.DateTimeFormat('en', { year: 'numeric' }).format(d)
+	let mo = new Intl.DateTimeFormat('en', { month: 'long' }).format(d)
+	let da = new Intl.DateTimeFormat('en', { day: '2-digit' }).format(d)
+	return `${da} ${mo} ${ye}`
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2887,11 +2887,6 @@ modern-normalize@^1.1.0:
   resolved "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.1.0.tgz#da8e80140d9221426bd4f725c6e11283d34f90b7"
   integrity sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==
 
-moment@^2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
Fixes #45 

Reduce bundle size by replacing moment.js with intl.
Refactored code for the same.